### PR TITLE
Add White Mode Tweak

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,7 +24,7 @@
 - To enable support for sidebar, open `user.js`, find `fp.tweak.sidebar-enabled` and set it to `true` or `false`.
 - To enable or disable White Mode, open `user.js`, find `browser.in-content.dark-mode` and set it to `true` or `false`. Then find and set `ui.systemUsesDarkTheme` to `1` or `0`.
 > [!NOTE]
-> To get the sidebar support you will need to install an extension called [Sidebar Tabs](https://github.com/asamuzaK/sidebarTabs)
+> To get the sidebar support you will need to install the [Sidebar Tabs](https://github.com/asamuzaK/sidebarTabs) extension.
 
 
 ***Enjoy your enhanced browsing experience!***

--- a/README.md
+++ b/README.md
@@ -15,19 +15,19 @@
 # How to install
 1. Go to `about:support` and click the "Open Folder/Show in Finder" button for the root directory of your browser profile/s.
 2. Download and copy the `chrome` folder and `user.js` into the profile folder.
-3. Restart firefox.
+3. Restart Firefox.
 
 # Tweaks
-- To enable macOS button style, open `user.js` and find `fp.tweak.macos-button` and set it to `true`.  
-- To disable bookmarks autohide open `user.js` and find `fp.tweak.autohide-bookmarks` and set it to `false`.
-- To enable or disable rounded corners, open `user.js` and find `fp.tweak.rounded-corners` and set it to `true` or `false`.  
-- To enable support for sidebar open `user.js` and find `fp.tweak.sidebar-enabled` and set it to `true` or `false`.  
-
+- To enable macOS button style, open `user.js`, find `fp.tweak.macos-button` and set it to `true`.  
+- To disable bookmarks autohide open `user.js`, find `fp.tweak.autohide-bookmarks` and set it to `false`.
+- To enable or disable rounded corners, open `user.js`, find `fp.tweak.rounded-corners` and set it to `true` or `false`.  
+- To enable support for sidebar, open `user.js`, find `fp.tweak.sidebar-enabled` and set it to `true` or `false`.
+- To enable or disable White Mode, open `user.js`, find `browser.in-content.dark-mode` and set it to `true` or `false`. Then find and set `ui.systemUsesDarkTheme` to `1` or `0`.
 > [!NOTE]
-> To get sidebar support you will need to install extension [Sidebar Tabs](https://github.com/asamuzaK/sidebarTabs)
+> To get the sidebar support you will need to install an extension called [Sidebar Tabs](https://github.com/asamuzaK/sidebarTabs)
 
 
-Enjoy your enhanced browsing experience!
+***Enjoy your enhanced browsing experience!***
 
 ## Star History
 


### PR DESCRIPTION
## White Mode tweak added for the ones who like it.
<img width="720" alt="w-theme" src="https://github.com/amnweb/firefox-plus/assets/158858932/25a5d03b-fbfa-4df1-a061-e5acea3fb049">![image](https://github.com/amnweb/firefox-plus/assets/158858932/05e11dc2-0791-4c14-8506-c46e0baabbf7)
(also some minor changes include some "and" being substituted with a comma, and a modification from the Notes _that you would probably like to modify a bit_)
![image](https://github.com/amnweb/firefox-plus/assets/158858932/1e4c0a1d-6955-4e9a-8062-63fc233409d8)




## Capitalized *"Firefox" in "How to install" tab
![image](https://github.com/amnweb/firefox-plus/assets/158858932/eac49ef2-3aee-4126-86f7-b65cddb29a2a)

## ... And look! The "Enjoy" (•ᴗ•) text is not shy anymore!!! [Bold and Italic for the extra sparkles]
![image](https://github.com/amnweb/firefox-plus/assets/158858932/c430c744-9757-4e7f-b964-32b4812af2a0)


*As I'm very new to pull request, I've mistakenly made 3 commits. Please use the* **5e2b1cd** *commit which is the first one*
